### PR TITLE
Add quotations for spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,8 +72,8 @@ function gulpPotomo(customOptions, cb) {
     moFileName = path.basename(file.path, '.po') + '.mo';
     mofileDest = path.join(tempFolder, moFileName);
 
-    command = 'msgfmt -o ' + mofileDest + ' ' + file.path;
-
+    command = 'msgfmt -o "' + mofileDest + '" "' + file.path+'"';
+    
     if (shell.exec(command).code !== 0) {
       this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Failed to Compile "*.po" files into binary "*.mo" files with "msgfmt".'));
       cb();


### PR DESCRIPTION
Added quotations around the command arguments so that path names with spaces won't throw out an error. Without this fix, potomo fails on paths like  C:\www\My Path With Spaces\mylanguagefile.mo
